### PR TITLE
Fix quickstart in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ You can do all of that in the command line using [curl](https://curl.se/) like t
 mkdir my-test-telemetry
 cd my-test-telemetry
 curl -O -L https://github.com/cisco-open/test-telemetry-generator/releases/latest/download/test-telemetry-generator-otel-proto-0.18.0-fatjar.jar
-curl -O https://raw.githubusercontent.com/cisco-open/test-telemetry-generator/master/example-definitions/entity-definition.yaml
-curl -O https://raw.githubusercontent.com/cisco-open/test-telemetry-generator/master/example-definitions/trace-definition.yaml
-curl -O https://raw.githubusercontent.com/cisco-open/test-telemetry-generator/master/example-definitions/cli-target-rest.yaml
+curl -O https://raw.githubusercontent.com/cisco-open/test-telemetry-generator/master/example-definitions/simple/entity-definition.yaml
+curl -O https://raw.githubusercontent.com/cisco-open/test-telemetry-generator/master/example-definitions/simple/trace-definition.yaml
 ```
 
 Your `my-test-telemetry` directory should now contain the following files:
@@ -46,7 +45,7 @@ $ ls
 cli-target-rest.yaml  entity-definition.yaml  test-telemetry-generator-otel-proto-0.18.0-fatjar.jar  trace-definition.yaml
 ```
 
-Next, open the `cli-target-rest.yml` with an editor of your choice and set the `restURL` to your OTLP HTTP endpoint. For example, if you use an [OpenTelemetry
+Next, create a file called `cli-target-rest.yml` with an editor of your choice and set the `restURL` to your OTLP HTTP endpoint. For example, if you use an [OpenTelemetry
 Collector](https://opentelemetry.io/docs/collector/) running on `localhost` with an `otlp` receiver listening on port `4318`, update your target config to look like the following:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -38,13 +38,6 @@ curl -O https://raw.githubusercontent.com/cisco-open/test-telemetry-generator/ma
 curl -O https://raw.githubusercontent.com/cisco-open/test-telemetry-generator/master/example-definitions/simple/trace-definition.yaml
 ```
 
-Your `my-test-telemetry` directory should now contain the following files:
-
-```shell
-$ ls
-cli-target-rest.yaml  entity-definition.yaml  test-telemetry-generator-otel-proto-0.18.0-fatjar.jar  trace-definition.yaml
-```
-
 Next, create a file called `cli-target-rest.yml` with an editor of your choice and set the `restURL` to your OTLP HTTP endpoint. For example, if you use an [OpenTelemetry
 Collector](https://opentelemetry.io/docs/collector/) running on `localhost` with an `otlp` receiver listening on port `4318`, update your target config to look like the following:
 
@@ -52,6 +45,14 @@ Collector](https://opentelemetry.io/docs/collector/) running on `localhost` with
 authMode: none
 restURL: http://localhost:4318/v1/traces
 ```
+
+Your `my-test-telemetry` directory should now contain the following files:
+
+```shell
+$ ls
+cli-target-rest.yaml  entity-definition.yaml  test-telemetry-generator-otel-proto-0.18.0-fatjar.jar  trace-definition.yaml
+```
+
 
 Finally, start the test-telemetry-generator:
 


### PR DESCRIPTION
* some of the URLs are broken
* cli-target-rpc.yaml is already in the new format, but not yet supported by the release.