### PR TITLE
Added support for filtering reporting resources for metrics

### DIFF
--- a/src/main/java/io/opentelemetry/contrib/generator/core/RuntimeModificationsThread.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/core/RuntimeModificationsThread.java
@@ -69,14 +69,12 @@ public class RuntimeModificationsThread implements Runnable {
                     && minsElapsed > eachModification.getStartAfterMinutes()
                     && minsElapsed <= eachModification.getEndAfterMinutes()) {
                 switch (eachModification.getResourceModificationType()) {
-                    case ADD:
-                        executeAddModification(eachModification.getResourceType(), eachModification.getModificationQuantity());
-                        break;
-                    case REMOVE:
-                        executeRemoveModification(eachModification.getResourceType(), eachModification.getModificationQuantity());
-                        break;
-                    case CHURN:
-                        executeChurnModification(eachModification.getResourceType(), eachModification.getModificationQuantity());
+                    case ADD ->
+                            executeAddModification(eachModification.getResourceType(), eachModification.getModificationQuantity());
+                    case REMOVE ->
+                            executeRemoveModification(eachModification.getResourceType(), eachModification.getModificationQuantity());
+                    case CHURN ->
+                            executeChurnModification(eachModification.getResourceType(), eachModification.getModificationQuantity());
                 }
                 modificationsUpdateTimestamps.put(eachModification.getModificationId(), currTime);
             }

--- a/src/main/java/io/opentelemetry/contrib/generator/core/dto/GeneratorResource.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/core/dto/GeneratorResource.java
@@ -41,6 +41,7 @@ public class GeneratorResource {
     private String type; //type of this resource. There can be multiple resources of this type.
     private boolean isActive; //if this resource is currently reporting any MELT data
     private Resource.Builder otelResource; //OTel representation of the resource
+    private Map<String, String> evaluatedAttributes;
     private Map<String, List<GeneratorResource>> childrenByType; //list of all the child resources of this resource, grouped by type
     private Map<String, List<GeneratorResource>> parentsByType; //list of all the parent resources of this resource, grouped by type
 
@@ -64,6 +65,13 @@ public class GeneratorResource {
         MapUtils.emptyIfNull(parentsByType)
                 .forEach((key, value) -> parentTypeCounts.put(key, CollectionUtils.emptyIfNull(value).size()));
         return parentTypeCounts;
+    }
+
+    public void setEvaluatedAttributes() {
+        evaluatedAttributes = new HashMap<>();
+        for (KeyValue eachKv: CollectionUtils.emptyIfNull(otelResource.getAttributesList())) {
+            evaluatedAttributes.put(eachKv.getKey(), CommonUtils.anyValueToString(eachKv.getValue()));
+        }
     }
 
     @Override
@@ -102,10 +110,9 @@ public class GeneratorResource {
 
     @Override
     public boolean equals(Object generatorResource) {
-        if (!(generatorResource instanceof GeneratorResource)) {
+        if (!(generatorResource instanceof GeneratorResource compareResource)) {
             return false;
         }
-        GeneratorResource compareResource = (GeneratorResource) generatorResource;
         if (!Objects.equals(this.type, compareResource.type)) {
             return false;
         }

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/logs/LogGeneratorThread.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/logs/LogGeneratorThread.java
@@ -22,6 +22,7 @@ import io.opentelemetry.contrib.generator.telemetry.GeneratorsStateProvider;
 import io.opentelemetry.contrib.generator.telemetry.dto.GeneratorState;
 import io.opentelemetry.contrib.generator.telemetry.jel.JELProvider;
 import io.opentelemetry.contrib.generator.telemetry.logs.dto.LogDefinition;
+import io.opentelemetry.contrib.generator.telemetry.misc.Constants;
 import io.opentelemetry.contrib.generator.telemetry.transport.PayloadHandler;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.common.v1.AnyValue;
@@ -82,8 +83,8 @@ public class LogGeneratorThread implements Runnable {
                             .setResource(eachResource)
                             .addScopeLogs(ScopeLogs.newBuilder()
                                     .setScope(InstrumentationScope.newBuilder()
-                                            .setName("@opentelemetry/vodka-exporter")
-                                            .setVersion("22.10.0")
+                                            .setName(Constants.SELF_NAME)
+                                            .setVersion(Constants.SELF_VERSION)
                                             .build())
                                     .addAllLogRecords(otelLogs)
                                     .build())
@@ -120,7 +121,7 @@ public class LogGeneratorThread implements Runnable {
         //resourceEndIndex is exclusive
         int resourceEndIndex;
         List<GeneratorResource> resourcesInResourceModel = ResourceModelProvider.getResourceModel(requestID).get(resourceName).stream()
-                .filter(GeneratorResource::isActive).collect(Collectors.toList());
+                .filter(GeneratorResource::isActive).toList();
         if (resourceCount >= resourcesInResourceModel.size()) {
             resourceEndIndex = resourcesInResourceModel.size();
         } else {

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/logs/dto/Logs.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/logs/dto/Logs.java
@@ -22,7 +22,6 @@ import lombok.Data;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Data
 public class Logs {

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/dto/MetricDefinition.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/dto/MetricDefinition.java
@@ -21,12 +21,15 @@ import io.opentelemetry.contrib.generator.telemetry.misc.Constants;
 import io.opentelemetry.contrib.generator.telemetry.misc.GeneratorUtils;
 import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 
 @Data
+@Slf4j
 public class MetricDefinition implements Cloneable {
 
     private String name;
@@ -40,12 +43,16 @@ public class MetricDefinition implements Cloneable {
     private Integer payloadFrequencySeconds;
     private Integer payloadCount;
     private Set<String> reportingResources;
+    private Map<String, Set<String>> filteredReportingResources;
     private Set<String> copyResourceAttributes;
     private Map<String, Object> attributes;
+    private Map<String, Map<String, String>> parsedFilteredReportingResources;
 
-    public void validate(String requestID, Set<String> allResourceTypes, Integer globalPayloadFrequency, Integer globalPayloadCount) {
+    public void validate(String requestID, Set<String> allResourceTypes, Integer globalPayloadFrequency,
+                         Integer globalPayloadCount) {
         validateMandatoryFields();
         validateResourceTypes(allResourceTypes);
+        parseFilteredReportingResources();
         setPayloadFrequencyAndPayloadCount(globalPayloadFrequency, globalPayloadCount);
         attributes = GeneratorUtils.addArgsToAttributeExpressions(requestID, "metric", name, attributes);
         if (isDouble == null) {
@@ -64,15 +71,18 @@ public class MetricDefinition implements Cloneable {
         validateMandatoryField(name, "unit", unit);
         validateMandatoryField(name, "otelType", otelType);
         validateMandatoryField(name, "valueFunction", valueFunction);
-        if (CollectionUtils.emptyIfNull(reportingResources).isEmpty()) {
-            throw new GeneratorException("Mandatory field 'reportingResources' not provided in metrics definition YAML for metric " + name);
+        if (CollectionUtils.emptyIfNull(reportingResources).isEmpty() &&
+                MapUtils.emptyIfNull(filteredReportingResources).isEmpty()) {
+            throw new GeneratorException("At least one resource type must be specified in either reportingResources" +
+                    " or filteredReportingResources for metric " + name);
         }
         validateOTelType();
     }
 
     private void validateMandatoryField(String metricName, String fieldName, String fieldValue) {
         if (StringUtils.defaultString(fieldValue).isBlank()) {
-            throw new GeneratorException("Mandatory field '" + fieldName + "' not provided in metrics definition YAML for metric: " + metricName);
+            throw new GeneratorException("Mandatory field '" + fieldName + "' not provided in the metrics definition " +
+                    "YAML for metric: " + metricName);
         }
     }
 
@@ -87,12 +97,14 @@ public class MetricDefinition implements Cloneable {
     private void validateAggregationTemporalityForSum() {
         if (otelType.equalsIgnoreCase(Constants.SUM)) {
             if (aggregationTemporality==null || aggregationTemporality.isBlank()) {
-                throw new GeneratorException("OTel type for metric " + name + " is of 'sum' type but Aggregation temporality not provided");
+                throw new GeneratorException("OTel type for metric " + name + " is of 'sum' type but Aggregation " +
+                        "temporality not provided");
             }
             //Check aggregation temporality is valid
-            if (!(aggregationTemporality.equalsIgnoreCase(Constants.CUMULATIVE) || aggregationTemporality.equalsIgnoreCase(Constants.DELTA))) {
-                throw new GeneratorException("Invalid aggregation temporality " + aggregationTemporality + " specified for metric " +
-                        name + ". Valid types are (Cumulative, Delta)");
+            if (!(aggregationTemporality.equalsIgnoreCase(Constants.CUMULATIVE) ||
+                    aggregationTemporality.equalsIgnoreCase(Constants.DELTA))) {
+                throw new GeneratorException("Invalid aggregation temporality " + aggregationTemporality +
+                        " specified for metric " + name + ". Valid types are (Cumulative, Delta)");
             }
         }
         validateAttributes();
@@ -103,10 +115,16 @@ public class MetricDefinition implements Cloneable {
     }
 
     private void validateResourceTypes(Set<String> allResourceTypes) {
-        for (String eachResource: reportingResources) {
+        for (String eachResource: CollectionUtils.emptyIfNull(reportingResources)) {
             if (!allResourceTypes.contains(eachResource)) {
-                throw new GeneratorException("Invalid resource type (" + eachResource + ") found in metric definition YAML " +
-                        "for metric " + name);
+                throw new GeneratorException("Invalid resource type (" + eachResource + ") found in " +
+                        "reportingResources for metric " + name + " in the metric definition YAML ");
+            }
+        }
+        for (String resourceType: MapUtils.emptyIfNull(filteredReportingResources).keySet()) {
+            if (!allResourceTypes.contains(resourceType)) {
+                throw new GeneratorException("Invalid resource type (" + resourceType + ") found in " +
+                        "filteredReportingResources for metric " + name + " in the metric definition YAML ");
             }
         }
     }
@@ -116,7 +134,8 @@ public class MetricDefinition implements Cloneable {
             payloadFrequencySeconds = globalPayloadFrequencySeconds;
         } else {
             if (payloadFrequencySeconds < 10) {
-                throw new GeneratorException("Override payload frequency defined for metric " + name + " is less than 10 seconds");
+                throw new GeneratorException("Override payload frequency defined for metric " + name +
+                        " is less than 10 seconds");
             }
         }
         if (payloadCount == null) {
@@ -124,6 +143,26 @@ public class MetricDefinition implements Cloneable {
         } else {
             if (payloadCount < 1) {
                 throw new GeneratorException("Override payload count defined for metric " + name + " is less than 1");
+            }
+        }
+    }
+
+    private void parseFilteredReportingResources() {
+        if (!MapUtils.emptyIfNull(filteredReportingResources).isEmpty()) {
+            parsedFilteredReportingResources = new HashMap<>();
+            for (Map.Entry<String, Set<String>> eachFilteredReportingResource: filteredReportingResources.entrySet()) {
+                String resourceType = eachFilteredReportingResource.getKey();
+                parsedFilteredReportingResources.put(resourceType, new HashMap<>());
+                for (String attributeFilter : eachFilteredReportingResource.getValue()) {
+                    String[] filterTokens = attributeFilter.split("=");
+                    if (filterTokens.length != 2) {
+                        log.warn("Attribute filter " + attributeFilter + " provided for resource type " +
+                                resourceType + " in the metric definition YAML for metric " + name + " is not valid. " +
+                                "Must contain a single '='");
+                        continue;
+                    }
+                    parsedFilteredReportingResources.get(resourceType).put(filterTokens[0], filterTokens[1]);
+                }
             }
         }
     }

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/misc/Constants.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/misc/Constants.java
@@ -42,4 +42,7 @@ public class Constants {
     public static final String TRACES_DEFINITION_YAML = "TRACES_DEFINITION_YAML";
 
     public static final String ENV_ALPHANUMERIC = "ENV_ALPHANUMERIC";
+    public static final String SELF_NAME = "@opentelemetry/test-telemetry-generator";
+    public static final String SELF_VERSION = "23.4.0";
+
 }

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/traces/SpansGenerator.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/traces/SpansGenerator.java
@@ -19,6 +19,7 @@ package io.opentelemetry.contrib.generator.telemetry.traces;
 import io.opentelemetry.contrib.generator.core.dto.GeneratorResource;
 import io.opentelemetry.contrib.generator.telemetry.ResourceModelProvider;
 import io.opentelemetry.contrib.generator.telemetry.jel.JELProvider;
+import io.opentelemetry.contrib.generator.telemetry.misc.Constants;
 import io.opentelemetry.contrib.generator.telemetry.traces.dto.RootSpanDefinition;
 import io.opentelemetry.contrib.generator.telemetry.traces.dto.SpanDefinition;
 import com.google.protobuf.ByteString;
@@ -76,11 +77,11 @@ public class SpansGenerator {
             for (var copyIndex=0; copyIndex<traceTree.getCopyCount(); copyIndex++) {
                 var copyIndexFinal = copyIndex;
                 List<GeneratorResource> validResources = resourceModel.get(eachSpanGroup.getKey()).stream()
-                        .filter(GeneratorResource::isActive).collect(Collectors.toList());
+                        .filter(GeneratorResource::isActive).toList();
                 int resourceIndex = (currentPostCount + copyIndex) % validResources.size();
                 List<Span.Builder> partialSpans = eachSpanGroup.getValue().stream()
                         .map(list -> list.get(copyIndexFinal))
-                        .collect(Collectors.toList());
+                        .toList();
                 List<Span> spans = new ArrayList<>();
                 for (Span.Builder eachPartialSpan: partialSpans) {
                     Set<String> attributeNames = traceTree.getTreeNodesPostOrder().get(traceTree.getSpansIndexMap()
@@ -93,8 +94,8 @@ public class SpansGenerator {
                         .setResource(validResources.get(resourceIndex).getOTelResource())
                         .addScopeSpans(ScopeSpans.newBuilder()
                                 .setScope(InstrumentationScope.newBuilder()
-                                        .setName("@opentelemetry/test-telemetry-generator")
-                                        .setVersion("22.10.0")
+                                        .setName(Constants.SELF_NAME)
+                                        .setVersion(Constants.SELF_VERSION)
                                         .build())
                                 .addAllSpans(spans)
                                 .build())


### PR DESCRIPTION
## Description

Currently, for selecting the resources that report a metric, we can only specify the resource type, meaning all of the resources of that type will report the metric. In this PR, we are allowing for constructs to filter the resources by their attribute values like so:

```
reportingResources:
    pod: ["k8s.node.name=svc-1-node"]
    container: ["k8s.namespace.name=frontend", "k8s.pod.name=svc-3-pod"]
```

The format for the filters is <ATTRIBUTE_NAME>=<ATTRIBUTE_VALUE> as seen above and we only support equality filter as of now. Also, multiple filters, if specified, are treated as the complete filter, meaning only the pods matching all the filter conditions will be selected.

The original field in metric definition file for specifying resource types `reportingResources` is still available and can be added the same way. This new way of specifying resources will be added under the new field `filteredReportingResources`. In case a resource type name is specified under both fields, `reportingResources` will take precedence, i.e. all of the resources of that type will report the metric.

## Type of Change

- [ ] New Feature
