### PR TITLE
Add uncaught exception handler

### DIFF
--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/misc/GeneratorExceptionHandler.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/misc/GeneratorExceptionHandler.java
@@ -1,0 +1,12 @@
+package io.opentelemetry.contrib.generator.telemetry.misc;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GeneratorExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        log.error("Error occurred in thread " + t.getName(), e);
+    }
+}


### PR DESCRIPTION
## Description

Addresses https://github.com/cisco-open/test-telemetry-generator/issues/82
Adding an instance of Thread.UncaughtExceptionHandler to all generator threads so that in case a thread crashes, a log message is displayed making the debugging easier.

## Type of Change

- [ ] Bug Fix
