### PR TITLE
Added support for filtering reporting resources for logs

### DIFF
--- a/example-definitions/json/log-definition.json
+++ b/example-definitions/json/log-definition.json
@@ -45,6 +45,15 @@
         "event.reason": "roundRobin([\"Pulling\", \"Pulled\", \"Created\", \"Pulling\", \"Backoff\"])",
         "event.message": "roundRobin([\"Pulling image k8s.gcr.io/echoserver:1.8\", \"Image downloaded\", \"Created container\", \"Pulling image cjknsjc/ccsdc:fff\", \"Error: ImagePullBackoff\"])"
       }
+    },
+    {
+      "severityOrderFunction": "severityDistributionCount([\"ERROR\", \"WARN\", \"DEBUG\"], [1, 1, 4])",
+      "payloadFrequencySeconds": 20,
+      "payloadCount": 2,
+      "copyCount": 200,
+      "filteredReportingResources": {
+        "node": ["k8s.cluster.name=cluster-skyrim"]
+      }
     }
   ]
 }

--- a/example-definitions/qa/log-definition.yaml
+++ b/example-definitions/qa/log-definition.yaml
@@ -47,3 +47,9 @@ logs:
       event.domain: 'roundRobin(["k8s"])'
       event.reason: 'roundRobin(["Pulling", "Pulled", "Created", "Pulling", "Backoff"])'
       event.message: 'roundRobin(["Pulling image k8s.gcr.io/echoserver:1.8", "Image downloaded", "Created container", "Pulling image cjknsjc/ccsdc:fff", "Error: ImagePullBackoff"])'
+  - severityOrderFunction: 'severityDistributionCount(["ERROR", "WARN", "DEBUG"], [1, 1, 4])'
+    payloadFrequencySeconds: 20
+    payloadCount: 2
+    copyCount: 200
+    filteredReportingResources:
+      node: ["k8s.cluster.name=cluster-skyrim"]

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/dto/MetricDefinition.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/dto/MetricDefinition.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.contrib.generator.telemetry.metrics.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.opentelemetry.contrib.generator.core.exception.GeneratorException;
 import io.opentelemetry.contrib.generator.telemetry.misc.Constants;
 import io.opentelemetry.contrib.generator.telemetry.misc.GeneratorUtils;
@@ -46,6 +47,7 @@ public class MetricDefinition implements Cloneable {
     private Map<String, Set<String>> filteredReportingResources;
     private Set<String> copyResourceAttributes;
     private Map<String, Object> attributes;
+    @JsonIgnore
     private Map<String, Map<String, String>> parsedFilteredReportingResources;
 
     public void validate(String requestID, Set<String> allResourceTypes, Integer globalPayloadFrequency,

--- a/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestAllGeneratorsWithJSONInput.java
+++ b/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestAllGeneratorsWithJSONInput.java
@@ -55,11 +55,14 @@ public class TestAllGeneratorsWithJSONInput {
         int METRIC_REPORTING_RESOURCES_COUNT = NETWORK_INTERFACE_COUNT + CONTAINER_COUNT + MACHINE_COUNT + NODE_COUNT +
                 POD_COUNT + DISK_COUNT + AWS_EBS_COUNT + AWS_RDS_COUNT;
         int LOG_REPORTING_RESOURCES_COUNT = CONTAINER_COUNT + NODE_COUNT + 2 * POD_COUNT + MACHINE_COUNT;
+        int LOG_FILTERED_RESOURCES = 5;
+        int LOG_FILTERED_PAYLOADS = 20;
         int metricPayloadCount = 10;
         int logsPayloadCount = 20;
         int POD_EVENTS_COUNT = 30 * 5;
         int expectedMetricPackets = METRIC_REPORTING_RESOURCES_COUNT * metricPayloadCount;
-        int expectedLogsPackets = LOG_REPORTING_RESOURCES_COUNT * logsPayloadCount + POD_EVENTS_COUNT;
+        int expectedLogsPackets = LOG_REPORTING_RESOURCES_COUNT * logsPayloadCount + POD_EVENTS_COUNT +
+                (LOG_FILTERED_RESOURCES * LOG_FILTERED_PAYLOADS);
         int expectedSpanPackets = 11518;
         Assert.assertEquals(testStore.getMetricsPacketCount(), expectedMetricPackets, "Mismatch in expected metric packets count");
         Assert.assertEquals(testStore.getLogsPacketCount(), expectedLogsPackets, "Mismatch in expected log packets count");
@@ -70,7 +73,7 @@ public class TestAllGeneratorsWithJSONInput {
     public void validateStorageCounts() {
         Assert.assertEquals(transportStorage.getStoredMetricsPayloads().size(), 8,
                 "Mismatch in resource type counts for metric payloads");
-        Assert.assertEquals(transportStorage.getStoredLogsPayloads().size(), 4,
+        Assert.assertEquals(transportStorage.getStoredLogsPayloads().size(), 5,
                 "Mismatch in resource type counts for log payloads");
         Assert.assertEquals(transportStorage.getStoredLogsPayloads().get("log_by_ttg_0").size(), 3,
                 "Mismatch in resource type counts for log payloads");
@@ -80,7 +83,7 @@ public class TestAllGeneratorsWithJSONInput {
                 "Mismatch in resource type counts for trace payloads");
         Assert.assertEquals(transportStorage.getMetricsResponses().size(), 8,
                 "Mismatch in resource type counts for metric response statuses");
-        Assert.assertEquals(transportStorage.getLogsResponses().size(), 4,
+        Assert.assertEquals(transportStorage.getLogsResponses().size(), 5,
                 "Mismatch in resource type counts for log response statuses");
         Assert.assertEquals(transportStorage.getTracesResponses().size(), 8,
                 "Mismatch in resource type counts for trace response statuses");

--- a/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestLogsGenerator.java
+++ b/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestLogsGenerator.java
@@ -38,12 +38,14 @@ public class TestLogsGenerator {
     private final int CONTAINER_COUNT_LOG = 150;
     private final int MACHINE_COUNT = 4;
     private final int NODE_COUNT = 25;
+    private final int FILTERED_NODE_COUNT = 5;
     private final int POD_COUNT = 10;
     private final int POD_EVENT_COUNT = 30;
     private final int POST_COUNT_K8S_LOG = 10;
     private final int POST_COUNT_LOG_LOG_1 = 2;
     private final int POST_COUNT_LOG_LOG_2 = 5;
     private final int POST_COUNT_K8S_EVENT = 5;
+    private final int FILTERED_NODE_PAYLOAD_COUNT = 2;
 
     @BeforeClass
     public void generateData() {
@@ -57,11 +59,13 @@ public class TestLogsGenerator {
     @Test
     public void testPayloadAndPacketCounts() {
         //Check payload count = Summation of all post counts per log definition
-        int expectedPayloadCount = 2 * POST_COUNT_K8S_LOG + POST_COUNT_LOG_LOG_1 + 2 * POST_COUNT_LOG_LOG_2 + POST_COUNT_K8S_EVENT;
+        int expectedPayloadCount = 2 * POST_COUNT_K8S_LOG + POST_COUNT_LOG_LOG_1 + 2 * POST_COUNT_LOG_LOG_2 +
+                POST_COUNT_K8S_EVENT + FILTERED_NODE_PAYLOAD_COUNT;
         Assert.assertEquals(testStore.getLogsPayloads().size(), expectedPayloadCount, "Mismatch in payload count");
         //Check packet count = Summation (payload count * number of resources) for every log
         int expectedPacketCount = (CONTAINER_COUNT_K8S + POD_COUNT) * POST_COUNT_K8S_LOG + NODE_COUNT * POST_COUNT_LOG_LOG_1
-                + (MACHINE_COUNT + CONTAINER_COUNT_LOG) * POST_COUNT_LOG_LOG_2 + POD_EVENT_COUNT * POST_COUNT_K8S_EVENT;
+                + (MACHINE_COUNT + CONTAINER_COUNT_LOG) * POST_COUNT_LOG_LOG_2 +
+                POD_EVENT_COUNT * POST_COUNT_K8S_EVENT + FILTERED_NODE_COUNT * FILTERED_NODE_PAYLOAD_COUNT;
         Assert.assertEquals(testStore.getLogsPacketCount(), expectedPacketCount, "Mismatch in resource logs packet count");
         //Check log count for each log = number of reporting resources * number of payloads defined per log definition
     }
@@ -73,7 +77,9 @@ public class TestLogsGenerator {
         int log1_Count = NODE_COUNT * POST_COUNT_LOG_LOG_1;
         int log2_Count = (MACHINE_COUNT + CONTAINER_COUNT_LOG) * POST_COUNT_LOG_LOG_2;
         int k8sEventsCount = POD_EVENT_COUNT * POST_COUNT_K8S_EVENT;
-        Assert.assertEquals(testStore.getLogsPacketCount(), k8sLogs_Count + log1_Count + log2_Count + k8sEventsCount,
+        int filteredNodeEvents = FILTERED_NODE_COUNT * FILTERED_NODE_PAYLOAD_COUNT;
+        Assert.assertEquals(testStore.getLogsPacketCount(), k8sLogs_Count + log1_Count + log2_Count +
+                        k8sEventsCount + filteredNodeEvents,
                 "Mismatch in logs count");
     }
 }

--- a/src/test/resources/test-definitions/logs-test-combined.json
+++ b/src/test/resources/test-definitions/logs-test-combined.json
@@ -41,6 +41,13 @@
         "event.reason": "roundRobin([\"Pulling\", \"Pulled\", \"Created\", \"Pulling\", \"Backoff\"])",
         "event.message": "roundRobin([\"Pulling image k8s.gcr.io/echoserver:1.8\", \"Image downloaded\", \"Created container\", \"Pulling image cjknsjc/ccsdc:fff\", \"Error: ImagePullBackoff\"])"
       }
+    },
+    {
+      "payloadCount": 20,
+      "severityOrderFunction": "severityDistributionCount([\"INFO\", \"ERROR\", \"WARN\", \"DEBUG\"], [5, 1, 1, 4])",
+      "filteredReportingResources": {
+        "node": ["k8s.cluster.name=cluster-aukus"]
+      }
     }
   ]
 }

--- a/src/test/resources/test-definitions/logs-test.yaml
+++ b/src/test/resources/test-definitions/logs-test.yaml
@@ -55,5 +55,6 @@ logs:
     payloadFrequencySeconds: 20
     payloadCount: 2
     copyCount: 10
+    copyResourceAttributes: ["k8s.pod.ip", "k8s.node.ip.internal"]
     filteredReportingResources:
       node: ["k8s.cluster.name=cluster-aukus"]

--- a/src/test/resources/test-definitions/logs-test.yaml
+++ b/src/test/resources/test-definitions/logs-test.yaml
@@ -51,3 +51,9 @@ logs:
       event.domain: 'roundRobin(["k8s"])'
       event.reason: 'roundRobin(["Pulling", "Pulled", "Created", "Pulling", "Backoff"])'
       event.message: 'roundRobin(["Pulling image k8s.gcr.io/echoserver:1.8", "Image downloaded", "Created container", "Pulling image cjknsjc/ccsdc:fff", "Error: ImagePullBackoff"])'
+  - severityOrderFunction: 'severityDistributionCount(["ERROR", "WARN", "DEBUG"], [1, 1, 4])'
+    payloadFrequencySeconds: 20
+    payloadCount: 2
+    copyCount: 10
+    filteredReportingResources:
+      node: ["k8s.cluster.name=cluster-aukus"]


### PR DESCRIPTION
## Description

We want to be able to select resources reporting logs by attributes key/value pairs. Currently we have -
```
    reportingResourcesCounts:
      container: 10
```
In this case for each payload we select the next 10 containers in a sequential manner. We should add support for expressions like -
```
    filteredReportingResources:
      container: "k8s.namespace.name=appd"
```

The format for the filters is <ATTRIBUTE_NAME>=<ATTRIBUTE_VALUE> as seen above and we only support equality filter as of now. Also, multiple filters, if specified, are treated as the complete filter, meaning only the resources matching all the filter conditions will be selected.
Further, any invalid filters (not having exactly one '=') will simply be ignored and in case a resource type is specified with no valid filters, or, effectively an empty set of filters, all resources of that type will be selected.

The original field in log definition file for specifying resource types `reportingResourcesCounts` is still available and can be added the same way. This new way of specifying resources will be added under the new field `filteredReportingResources`. In case a resource type name is specified under both fields, this will result in a validation failure as it might result in the same resource being reported twice with the same log/event.

## Type of Change

- [ ] New Feature

