### PR TITLE
Handle plain strings in expressions

### DIFF
--- a/src/main/java/io/opentelemetry/contrib/generator/core/ResourceModelGenerator.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/core/ResourceModelGenerator.java
@@ -17,12 +17,12 @@
 package io.opentelemetry.contrib.generator.core;
 
 import io.opentelemetry.contrib.generator.core.dto.*;
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.core.jel.JELProvider;
 import io.opentelemetry.contrib.generator.core.jel.methods.ResourceModelExpressions;
 import io.opentelemetry.contrib.generator.core.utils.CommonUtils;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.resource.v1.Resource;
-import jakarta.el.ELProcessor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -47,7 +47,7 @@ public class ResourceModelGenerator {
 
     private final Map<String, ResourceDefinition> allResources; //input resource definitions
     private final String requestID;
-    private static final ELProcessor jelProcessor = JELProvider.getJelProcessor();
+    private static final ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
     private static Map<String, List<GeneratorResource>> resourceModel; //output resource model
     private Map<String, ResourceType> typeMappings; //stores parent & child types for each resource type
 
@@ -145,7 +145,7 @@ public class ResourceModelGenerator {
                 var nextChildIndex = 0;
                 //For each resource of the parent type
                 for (var parentCounter = 0; parentCounter < parentType.getCountWithRuntimeModifications(); parentCounter++) {
-                    int count = (int) jelProcessor.eval(eachChildTypeExpr.getValue());
+                    int count = jelProcessor.eval(eachChildTypeExpr.getValue());
                     int childEndIndex = nextChildIndex + count;
                     if (childEndIndex > childrenSize) {
                         childEndIndex = childrenSize;

--- a/src/main/java/io/opentelemetry/contrib/generator/core/jel/ExpressionProcessor.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/core/jel/ExpressionProcessor.java
@@ -1,0 +1,19 @@
+package io.opentelemetry.contrib.generator.core.jel;
+
+import jakarta.el.ELProcessor;
+import jakarta.el.PropertyNotFoundException;
+
+public class ExpressionProcessor extends ELProcessor {
+
+    public ExpressionProcessor() {
+        super();
+    }
+
+    public <T> T eval(String expression) {
+        try {
+            return super.eval(expression);
+        } catch (PropertyNotFoundException exception) {
+            return (T) expression;
+        }
+    }
+}

--- a/src/main/java/io/opentelemetry/contrib/generator/core/jel/JELProvider.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/core/jel/JELProvider.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.contrib.generator.core.jel;
 
 import io.opentelemetry.contrib.generator.core.exception.GeneratorException;
-import jakarta.el.ELProcessor;
 
 import java.util.Arrays;    
 import java.util.List;
@@ -27,13 +26,13 @@ import java.util.List;
  */
 public class JELProvider {
 
-    private static ELProcessor jelProcessor;
+    private static ExpressionProcessor jelProcessor;
 
     private JELProvider() {}
 
-    public static ELProcessor getJelProcessor() {
+    public static ExpressionProcessor getJelProcessor() {
         if (jelProcessor == null) {
-            jelProcessor = new ELProcessor();
+            jelProcessor = new ExpressionProcessor();
             var expressionsClass = "io.opentelemetry.contrib.generator.core.jel.methods.ResourceModelExpressions";
             List<String> methods = Arrays.asList("counter", "UUIDFromStringCounter", "roundRobin", "alphanumericSequenceFromEnv",
                     "alphanumericSequence", "IPv4Sequence", "distribution", "count", "getLong", "getDouble", "getBoolean");

--- a/src/main/java/io/opentelemetry/contrib/generator/core/jel/methods/ResourceModelExpressions.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/core/jel/methods/ResourceModelExpressions.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.contrib.generator.core.jel.methods;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.core.jel.JELProvider;
 import io.opentelemetry.contrib.generator.core.jel.helpers.AlphanumericHelper;
 import io.opentelemetry.contrib.generator.core.jel.helpers.IPHelper;
@@ -40,7 +41,7 @@ public class ResourceModelExpressions {
     private static final ConcurrentHashMap<String, Integer> counters = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, Double> doubleCounters = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, String> stringCounters = new ConcurrentHashMap<>();
-    private static final ELProcessor jelProcessor = JELProvider.getJelProcessor();
+    private static final ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
     public static String expressionsGlobalKey = ""; //Modified by the resource model generator every time a new resource/attribute is being processed
 
     private ResourceModelExpressions() {}

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/jel/JELProvider.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/jel/JELProvider.java
@@ -17,10 +17,10 @@
 package io.opentelemetry.contrib.generator.telemetry.jel;
 
 import io.opentelemetry.contrib.generator.core.exception.GeneratorException;
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.jel.methods.LogSeverityGenerator;
 import io.opentelemetry.contrib.generator.telemetry.jel.methods.MetricValueGenerators;
 import io.opentelemetry.contrib.generator.telemetry.jel.methods.MELTAttributeGenerators;
-import jakarta.el.ELProcessor;
 
 import java.util.List;
 
@@ -29,13 +29,13 @@ import java.util.List;
  */
 public class JELProvider {
 
-    private static ELProcessor jelProcessor;
+    private static ExpressionProcessor jelProcessor;
 
     private JELProvider() {}
 
-    public static ELProcessor getJelProcessor() {
+    public static ExpressionProcessor getJelProcessor() {
         if (jelProcessor == null) {
-            jelProcessor = new ELProcessor();
+            jelProcessor = new ExpressionProcessor();
             defineMetricFunction("arithmeticSequence", String.class, String.class, double.class, double.class, String.class);
             defineMetricFunction("arithmeticSequenceSummary", String.class, String.class, double.class, double.class, String.class, int.class);
             defineMetricFunction("geometricSequence", String.class, String.class, double.class, double.class, String.class);

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/jel/methods/MELTAttributeGenerators.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/jel/methods/MELTAttributeGenerators.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.contrib.generator.telemetry.jel.methods;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.core.jel.helpers.AlphanumericHelper;
 import io.opentelemetry.contrib.generator.core.jel.helpers.IPHelper;
 import io.opentelemetry.contrib.generator.core.jel.methods.ResourceModelExpressions;
@@ -43,7 +44,7 @@ public class MELTAttributeGenerators {
     private static final ConcurrentHashMap<String, Integer> counters = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, Double> doubleCounters = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, String> stringCounters = new ConcurrentHashMap<>();
-    private static final ELProcessor jelProcessor = JELProvider.getJelProcessor();
+    private static final ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
 
     private MELTAttributeGenerators() {}
 

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/jel/methods/MetricValueGenerators.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/jel/methods/MetricValueGenerators.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.contrib.generator.telemetry.jel.methods;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.GeneratorsStateProvider;
 import jakarta.el.ELProcessor;
 
@@ -35,7 +36,7 @@ import java.util.stream.IntStream;
 @SuppressWarnings("unused")
 public class MetricValueGenerators {
 
-    private static final ELProcessor jelProcessor = new ELProcessor();
+    private static final ExpressionProcessor jelProcessor = new ExpressionProcessor();
     private static final ConcurrentMap<String, Double> controlledRandom = new ConcurrentHashMap<>();
     private static final DecimalFormat formatter = new DecimalFormat("##.##");
 

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/logs/LogGeneratorThread.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/logs/LogGeneratorThread.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.contrib.generator.telemetry.logs;
 
 import io.opentelemetry.contrib.generator.core.dto.GeneratorResource;
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.ResourceModelProvider;
 import io.opentelemetry.contrib.generator.telemetry.GeneratorsStateProvider;
 import io.opentelemetry.contrib.generator.telemetry.dto.GeneratorState;
@@ -31,7 +32,6 @@ import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.logs.v1.ScopeLogs;
 import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.logs.v1.LogRecord;
-import jakarta.el.ELProcessor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
@@ -53,7 +53,7 @@ public class LogGeneratorThread implements Runnable {
     private final LogDefinition logDefinition;
     private final PayloadHandler payloadHandler;
     private final GeneratorState<LogGeneratorThread> logGeneratorState;
-    private final ELProcessor jelProcessor;
+    private final ExpressionProcessor jelProcessor;
     private int currentPayloadCount;
 
     public LogGeneratorThread(LogDefinition logDefinition, PayloadHandler payloadHandler, String requestID) {

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/GaugeGenerator.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/GaugeGenerator.java
@@ -16,12 +16,12 @@
 
 package io.opentelemetry.contrib.generator.telemetry.metrics;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.metrics.dto.MetricDefinition;
 import io.opentelemetry.contrib.generator.telemetry.misc.GeneratorUtils;
 import io.opentelemetry.proto.metrics.v1.Gauge;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
-import jakarta.el.ELProcessor;
 
 import java.util.concurrent.TimeUnit;
 
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class GaugeGenerator {
 
-    private final ELProcessor jelProcessor;
+    private final ExpressionProcessor jelProcessor;
 
-    public GaugeGenerator(ELProcessor jelProcessor) {
+    public GaugeGenerator(ExpressionProcessor jelProcessor) {
         this.jelProcessor = jelProcessor;
     }
 

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/MetricGeneratorThread.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/MetricGeneratorThread.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.contrib.generator.telemetry.metrics;
 
 import io.opentelemetry.contrib.generator.core.dto.GeneratorResource;
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.GeneratorsStateProvider;
 import io.opentelemetry.contrib.generator.telemetry.dto.GeneratorState;
 import io.opentelemetry.contrib.generator.telemetry.misc.GeneratorUtils;
@@ -30,7 +31,6 @@ import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.metrics.v1.*;
 import io.opentelemetry.proto.resource.v1.Resource;
-import jakarta.el.ELProcessor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -62,7 +62,7 @@ public class MetricGeneratorThread implements Runnable {
         this.metrics = metrics.stream().collect(Collectors.toMap(MetricDefinition::getName, Function.identity()));
         this.payloadHandler = payloadHandler;
         this.metricGeneratorState = GeneratorsStateProvider.getMetricGeneratorState(requestID);
-        ELProcessor jelProcessor = JELProvider.getJelProcessor();
+        ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
         gaugeGenerator = new GaugeGenerator(jelProcessor);
         sumGenerator = new SumGenerator(requestID, jelProcessor);
         summaryGenerator = new SummaryGenerator(jelProcessor);

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/SumGenerator.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/SumGenerator.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.contrib.generator.telemetry.metrics;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.GeneratorsStateProvider;
 import io.opentelemetry.contrib.generator.telemetry.metrics.dto.MetricDefinition;
 import io.opentelemetry.contrib.generator.telemetry.misc.GeneratorUtils;
@@ -23,7 +24,6 @@ import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 import io.opentelemetry.proto.metrics.v1.Sum;
-import jakarta.el.ELProcessor;
 
 import java.util.concurrent.TimeUnit;
 
@@ -33,9 +33,9 @@ import java.util.concurrent.TimeUnit;
 public class SumGenerator {
 
     private final String requestID;
-    private final ELProcessor jelProcessor;
+    private final ExpressionProcessor jelProcessor;
 
-    public SumGenerator(String requestID, ELProcessor jelProcessor) {
+    public SumGenerator(String requestID, ExpressionProcessor jelProcessor) {
         this.requestID = requestID;
         this.jelProcessor = jelProcessor;
     }

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/SummaryGenerator.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/metrics/SummaryGenerator.java
@@ -16,12 +16,12 @@
 
 package io.opentelemetry.contrib.generator.telemetry.metrics;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.metrics.dto.MetricDefinition;
 import io.opentelemetry.contrib.generator.telemetry.misc.GeneratorUtils;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.Summary;
 import io.opentelemetry.proto.metrics.v1.SummaryDataPoint;
-import jakarta.el.ELProcessor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -36,9 +36,9 @@ import java.util.stream.Collectors;
 @Slf4j
 public class SummaryGenerator {
 
-    private final ELProcessor jelProcessor;
+    private final ExpressionProcessor jelProcessor;
 
-    public SummaryGenerator(ELProcessor jelProcessor) {
+    public SummaryGenerator(ExpressionProcessor jelProcessor) {
         this.jelProcessor = jelProcessor;
     }
 

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/misc/GeneratorUtils.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/misc/GeneratorUtils.java
@@ -17,12 +17,12 @@
 package io.opentelemetry.contrib.generator.telemetry.misc;
 
 import io.opentelemetry.contrib.generator.core.exception.GeneratorException;
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.core.utils.CommonUtils;
 
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.resource.v1.Resource;
-import jakarta.el.ELProcessor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 
@@ -86,7 +86,7 @@ public class GeneratorUtils {
         return attrs;
     }
 
-    public static List<KeyValue> getEvaluatedAttributes(ELProcessor jelProcessor, Map<String, Object> attributesDefinitions) {
+    public static List<KeyValue> getEvaluatedAttributes(ExpressionProcessor jelProcessor, Map<String, Object> attributesDefinitions) {
         List<KeyValue> attributes = new ArrayList<>();
         KeyValue eachAttribute;
         for (Map.Entry<String, Object> definedAttributes: MapUtils.emptyIfNull(attributesDefinitions).entrySet()) {

--- a/src/main/java/io/opentelemetry/contrib/generator/telemetry/traces/SpansGenerator.java
+++ b/src/main/java/io/opentelemetry/contrib/generator/telemetry/traces/SpansGenerator.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.contrib.generator.telemetry.traces;
 
 import io.opentelemetry.contrib.generator.core.dto.GeneratorResource;
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.ResourceModelProvider;
 import io.opentelemetry.contrib.generator.telemetry.jel.JELProvider;
 import io.opentelemetry.contrib.generator.telemetry.misc.Constants;
@@ -27,7 +28,6 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.trace.v1.*;
 import io.opentelemetry.sdk.trace.IdGenerator;
-import jakarta.el.ELProcessor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,7 +35,6 @@ import static io.opentelemetry.contrib.generator.telemetry.misc.GeneratorUtils.*
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Slf4j
@@ -44,7 +43,7 @@ public class SpansGenerator {
     private final RootSpanDefinition traceTree;
     private final String groupName;
     private final String requestID;
-    private final ELProcessor jelProcessor;
+    private final ExpressionProcessor jelProcessor;
     private ByteString[] traceIds;
     private long[] startTimes;
     private long[] endTimes;

--- a/src/test/java/io/opentelemetry/contrib/generator/core/TestExpressionMethods.java
+++ b/src/test/java/io/opentelemetry/contrib/generator/core/TestExpressionMethods.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.contrib.generator.core;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.core.jel.JELProvider;
 import io.opentelemetry.contrib.generator.core.jel.methods.ResourceModelExpressions;
-import jakarta.el.ELProcessor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
@@ -29,7 +29,7 @@ import java.util.stream.IntStream;
 
 public class TestExpressionMethods {
 
-    private final ELProcessor jelProcessor = JELProvider.getJelProcessor();
+    private final ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
 
     @Test
     public void testCounter() {
@@ -199,5 +199,11 @@ public class TestExpressionMethods {
             Assert.assertEquals(jelProcessor.eval(expression3), outputs3.get(i), "Mismatch at index " + i);
             Assert.assertEquals(jelProcessor.eval(expression4), outputs4.get(i), "Mismatch at index " + i);
         }
+    }
+
+    @Test
+    public void testExpressionlessString() {
+        String stringVal = "testValue";
+        Assert.assertEquals(jelProcessor.eval(stringVal), stringVal);
     }
 }

--- a/src/test/java/io/opentelemetry/contrib/generator/core/TestResourceModelGenerator.java
+++ b/src/test/java/io/opentelemetry/contrib/generator/core/TestResourceModelGenerator.java
@@ -19,6 +19,7 @@ package io.opentelemetry.contrib.generator.core;
 import io.opentelemetry.contrib.generator.core.dto.Resources;
 import io.opentelemetry.contrib.generator.core.dto.ResourceDefinition;
 import io.opentelemetry.contrib.generator.core.dto.GeneratorResource;
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.core.jel.JELProvider;
 import io.opentelemetry.contrib.generator.core.jel.methods.ResourceModelExpressions;
 import io.opentelemetry.contrib.generator.core.utils.CommonUtils;
@@ -26,7 +27,6 @@ import io.opentelemetry.contrib.generator.telemetry.misc.Constants;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.opentelemetry.proto.common.v1.KeyValue;
-import jakarta.el.ELProcessor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -51,7 +51,7 @@ public class TestResourceModelGenerator {
 
     private Resources resources, resourcesWithRuntimeMods;
     private Map<String, List<GeneratorResource>> resourceModel, resourceModelRuntimeMods;
-    private final ELProcessor jelProcessor = JELProvider.getJelProcessor();
+    private final ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
 
     @BeforeClass
     public void generateModel() {

--- a/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestMELTAttributeExpressions.java
+++ b/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestMELTAttributeExpressions.java
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.contrib.generator.telemetry;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.core.jel.methods.ResourceModelExpressions;
 import io.opentelemetry.contrib.generator.telemetry.jel.JELProvider;
 import io.opentelemetry.contrib.generator.telemetry.jel.methods.MELTAttributeGenerators;
 import io.opentelemetry.contrib.generator.telemetry.misc.Constants;
-import jakarta.el.ELProcessor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
@@ -31,7 +31,7 @@ import java.util.stream.IntStream;
 
 public class TestMELTAttributeExpressions {
 
-    private final ELProcessor jelProcessor = JELProvider.getJelProcessor();
+    private final ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
     private final String requestID = UUID.randomUUID().toString();
 
     @Test
@@ -207,5 +207,11 @@ public class TestMELTAttributeExpressions {
         String expression = "getBoolean(count(\"" + requestID + "\", \"metric\", \"cpu.used\", \"boolexpr\") % 2)";
         List<Boolean> expectedValues = Arrays.asList(false, true, false, true, false);
         IntStream.range(0, 5).forEach(i -> Assert.assertEquals(jelProcessor.eval(expression), expectedValues.get(i)));
+    }
+
+    @Test
+    public void testString() {
+        String stringVal = "testString";
+        Assert.assertEquals(jelProcessor.eval(stringVal), stringVal);
     }
 }

--- a/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestValueExpressions.java
+++ b/src/test/java/io/opentelemetry/contrib/generator/telemetry/TestValueExpressions.java
@@ -16,13 +16,13 @@
 
 package io.opentelemetry.contrib.generator.telemetry;
 
+import io.opentelemetry.contrib.generator.core.jel.ExpressionProcessor;
 import io.opentelemetry.contrib.generator.telemetry.dto.GeneratorState;
 import io.opentelemetry.contrib.generator.telemetry.helpers.TestPayloadHandler;
 import io.opentelemetry.contrib.generator.telemetry.logs.LogGeneratorThread;
 import io.opentelemetry.contrib.generator.telemetry.jel.JELProvider;
 import io.opentelemetry.contrib.generator.telemetry.logs.dto.LogDefinition;
 import io.opentelemetry.contrib.generator.telemetry.metrics.MetricGeneratorThread;
-import jakarta.el.ELProcessor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
@@ -40,7 +40,7 @@ import java.util.stream.IntStream;
 
 public class TestValueExpressions {
 
-    private final ELProcessor jelProcessor = JELProvider.getJelProcessor();
+    private final ExpressionProcessor jelProcessor = JELProvider.getJelProcessor();
     private final int[] VALUES_TO_CHECK = new int[]{0, 3, 6, 10, 13};
     private static final DecimalFormat doubleFormatter = new DecimalFormat("0.00");
     private final String GENERATOR_KEY = "ExpressionsTest";
@@ -297,4 +297,6 @@ public class TestValueExpressions {
             Assert.assertEquals(actual, expected.get(i));
         }
     }
+
+
 }

--- a/src/test/resources/test-definitions/logs-test.yaml
+++ b/src/test/resources/test-definitions/logs-test.yaml
@@ -18,6 +18,7 @@ globalPayloadFrequencySeconds: 30
 logs:
   - attributes:
       log.labels: '{"generator": roundRobin(["Telemetry-Generator", "Telemetry-Generator-v2"]), "type": "k8s"}'
+      type: 'log'
     severityOrderFunction: 'severityDistributionCount(["INFO", "ERROR", "DEBUG"], [1, 2, 3])'
     payloadFrequencySeconds: 20
     payloadCount: 10

--- a/src/test/resources/test-definitions/metrics-test.yaml
+++ b/src/test/resources/test-definitions/metrics-test.yaml
@@ -26,6 +26,7 @@ metrics:
     reportingResources: [network_interface, container, machine]
     attributes:
       system.internal.ip: 'IPv4Sequence("10.134.1.34")'
+      unit: 'kbps'
   - name: system.network.out.kb.sec
     unit: kBy/s
     otelType: summary

--- a/src/test/resources/test-definitions/resource-definition.yaml
+++ b/src/test/resources/test-definitions/resource-definition.yaml
@@ -78,6 +78,7 @@ resources:
     childrenDistribution:
       container: 'distribution(2, 0, 0)'
     attributes:
+      k8s.resource.type: 'k8s.pod'
       k8s.pod.ip: 'IPv4Sequence("133.29.54.1")'
       k8s.pod.status: 'roundRobin(["Pending","Running","Succeeded","Unknown"])'
       k8s.pod.labels: '{"app": alphanumericSequence("gnrtrx").concat("-service"), "ip": IPv4Sequence("133.45.54.2"), "version": roundRobin(["latest", "22.5.0-142"])}'

--- a/src/test/resources/test-definitions/trace-definition.yaml
+++ b/src/test/resources/test-definitions/trace-definition.yaml
@@ -21,7 +21,7 @@ rootSpans:
     reportingResource: http_backend
     copyResourceAttributes: ["http_port"]
     attributes:
-      type: 'roundRobin(["REST"])'
+      type: 'REST'
       url: 'roundRobin(["/healthcheck"])'
     payloadCount: 10
     copyCount: 20


### PR DESCRIPTION
## Description

Instead of an expression, if we want to specify a plain string value, it has to be wrapped around the roundRobin function with a single value.
Users will be able to specify a simple string without workarounds instead of expressions.

## Type of Change

- [ ] Bug Fix

