### PR TITLE
Fix missing Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-oraclelinux8 as builder
+FROM eclipse-temurin:17-jdk-ubi9-minimal as builder
 
 USER root
 


### PR DESCRIPTION
This fixes /issues/108 by updating the Dockerfile to use an actively maintained base image, the old image was deprecated and no longer available.

## Description
This updates the base image to a new, currently maintained base image that provides the needed jdk.

I verified this fix works by running `docker run -v HOST_DEFINITIONS_PATH:/definitions test_telemetry_generator:local` and the docker container builds and runs now, as expected (was previously broken).

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
